### PR TITLE
Read dynamic schema from `QueryEntity`s

### DIFF
--- a/ignite-rs/src/cache.rs
+++ b/ignite-rs/src/cache.rs
@@ -258,6 +258,8 @@ pub struct QueryField {
     pub(crate) type_name: String,
     pub(crate) key_field: bool,
     pub(crate) not_null_constraint: bool,
+    pub(crate) precision: i32,
+    pub(crate) scale: i32,
 }
 
 #[derive(Clone, Debug)]

--- a/ignite-rs/src/protocol/cache_config.rs
+++ b/ignite-rs/src/protocol/cache_config.rs
@@ -12,8 +12,8 @@ use crate::error::IgniteError;
 use crate::error::IgniteResult;
 use crate::protocol::cache_config::ConfigPropertyCode::*;
 use crate::protocol::{
-    read_bool, read_i32, read_i64, read_u8, write_bool, write_i16, write_i32, write_i64,
-    write_string_type_code, write_u8,
+    read_bool, read_i32, read_i64, read_object, read_u8, write_bool, write_i16, write_i32,
+    write_i64, write_string_type_code, write_u8,
 };
 use crate::ReadableType;
 use std::io;
@@ -256,8 +256,8 @@ fn read_query_entities(reader: &mut impl Read) -> IgniteResult<Vec<QueryEntity>>
         let key_type = String::read(reader)?.unwrap();
         let value_type = String::read(reader)?.unwrap();
         let table = String::read(reader)?.unwrap();
-        let key_field = String::read(reader)?.unwrap();
-        let value_field = String::read(reader)?.unwrap();
+        let key_field = String::read(reader)?.unwrap_or("".to_string());
+        let value_field = String::read(reader)?.unwrap_or("".to_string());
         let query_fields = read_query_fields(reader)?;
         let field_aliases = read_query_field_aliases(reader)?;
         let query_indexes = read_query_indexes(reader)?;
@@ -300,11 +300,16 @@ fn read_query_fields(reader: &mut impl Read) -> IgniteResult<Vec<QueryField>> {
         let type_name = String::read(reader)?.unwrap();
         let key_field = read_bool(reader)?;
         let not_null_constraint = read_bool(reader)?;
+        let _default_val = read_object(reader)?;
+        let precision = read_i32(reader)?;
+        let scale = read_i32(reader)?;
         result.push(QueryField {
             name,
             type_name,
             key_field,
             not_null_constraint,
+            precision,
+            scale,
         })
     }
     Ok(result)

--- a/ignite-rs/src/protocol/complex_obj.rs
+++ b/ignite-rs/src/protocol/complex_obj.rs
@@ -1,0 +1,84 @@
+use crate::cache::{QueryEntity, QueryField};
+use crate::error::{IgniteError, IgniteResult};
+use std::sync::Arc;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum IgniteType {
+    String,
+    Long,
+    Int,
+    Short,
+    Bool,
+    Timestamp,
+    Decimal(i32, i32), // precision, scale
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct IgniteField {
+    pub name: String,
+    pub r#type: IgniteType,
+}
+
+// https://apacheignite.readme.io/docs/binary-client-protocol-data-format#schema
+#[derive(Debug, PartialEq, Eq)]
+pub struct ComplexObjectSchema {
+    pub type_name: String,
+    pub fields: Vec<IgniteField>,
+}
+
+impl ComplexObjectSchema {
+    /// Find the key and value DynamicIgniteTypes for a table.
+    pub fn infer_schemas(
+        entity: &QueryEntity,
+    ) -> IgniteResult<(Arc<ComplexObjectSchema>, Arc<ComplexObjectSchema>)> {
+        let key_fields: Vec<_> = entity
+            .query_fields
+            .iter()
+            .filter(|f| f.key_field || entity.key_field == f.name)
+            .collect();
+        let val_fields: Vec<_> = entity
+            .query_fields
+            .iter()
+            .filter(|f| !f.key_field && entity.key_field != f.name)
+            .collect();
+        let key_fields = Self::convert_fields(&key_fields)?;
+        let val_fields = Self::convert_fields(&val_fields)?;
+        let k = ComplexObjectSchema {
+            type_name: entity.key_type.clone(),
+            fields: key_fields,
+        };
+        let v = ComplexObjectSchema {
+            type_name: entity.value_type.clone(),
+            fields: val_fields,
+        };
+        Ok((Arc::new(k), Arc::new(v)))
+    }
+
+    fn convert_fields(qry_fields: &[&QueryField]) -> IgniteResult<Vec<IgniteField>> {
+        let mut fields = vec![];
+        for f in qry_fields.iter() {
+            let t: IgniteType = match f.type_name.as_str() {
+                "java.lang.Long" => IgniteType::Long,
+                "java.lang.Short" => IgniteType::Short,
+                "java.lang.String" => IgniteType::String,
+                "java.sql.Timestamp" => IgniteType::Timestamp,
+                "java.lang.Integer" => IgniteType::Int,
+                "java.lang.Boolean" => IgniteType::Bool,
+                "java.math.BigDecimal" => IgniteType::Decimal(f.precision, f.scale),
+                _ => Err(IgniteError::from(
+                    format!("Unknown field type: {}", f.type_name).as_str(),
+                ))?,
+            };
+            let field = IgniteField {
+                name: f.name.to_string(),
+                r#type: t,
+            };
+            fields.push(field);
+        }
+        Ok(fields)
+    }
+
+    pub fn type_name(&self) -> &str {
+        self.type_name.as_str()
+    }
+}

--- a/ignite-rs/src/protocol/mod.rs
+++ b/ignite-rs/src/protocol/mod.rs
@@ -7,6 +7,7 @@ use crate::{Enum, ReadableType};
 use std::convert::TryFrom;
 
 pub(crate) mod cache_config;
+pub mod complex_obj;
 pub(crate) mod data_types;
 
 pub const FLAG_USER_TYPE: u16 = 0x0001;
@@ -89,6 +90,18 @@ impl TryFrom<u8> for TypeCode {
 pub(crate) enum Flag {
     Success,
     Failure { err_msg: String },
+}
+
+fn read_object(reader: &mut impl Read) -> IgniteResult<Option<()>> {
+    let flag = read_u8(reader)?;
+    let code = TypeCode::try_from(flag);
+    let code = code?;
+    match code {
+        TypeCode::Null => Ok(Some(())),
+        _ => Err(IgniteError::from(
+            format!("Cannot read TypeCode {}", flag).as_str(),
+        )),
+    }
 }
 
 /// Reads data objects that are wrapped in the WrappedData(type code = 27)

--- a/ignite-rs/tests/int-test.rs
+++ b/ignite-rs/tests/int-test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod int_test {
-    use ignite_rs::{ClientConfig, Ignite, new_client};
+    use ignite_rs::protocol::complex_obj::{ComplexObjectSchema, IgniteField, IgniteType};
+    use ignite_rs::{new_client, ClientConfig, Ignite};
 
     #[test]
     fn sanity_test() {
@@ -16,4 +17,69 @@ mod int_test {
         assert_eq!(actual, expected);
     }
 
+    #[test]
+    fn should_read_schema() {
+        let config = ClientConfig::new("127.0.0.1:10800");
+        let mut ignite = new_client(config).unwrap();
+
+        let table_name = "SQL_PUBLIC_RAINBOW";
+        let cfg = ignite.get_cache_config(table_name).unwrap();
+        let entities = cfg.query_entities.unwrap();
+
+        assert_eq!(entities.len(), 1);
+
+        let entity = entities.last().unwrap();
+
+        let cfg = ignite.get_cache_config(table_name).unwrap();
+        let entity = cfg.query_entities.unwrap().last().unwrap().clone();
+        let (ks, vs) = ComplexObjectSchema::infer_schemas(&entity).unwrap();
+
+        assert_eq!(
+            *ks,
+            ComplexObjectSchema {
+                type_name: "java.lang.Long".to_string(),
+                fields: vec![IgniteField {
+                    name: "BIG".to_string(),
+                    r#type: IgniteType::Long
+                }]
+            }
+        );
+
+        assert_eq!(
+            *vs,
+            ComplexObjectSchema {
+                type_name: vs.type_name().to_string(),
+                fields: vec![
+                    IgniteField {
+                        name: "BOOL".to_string(),
+                        r#type: IgniteType::Bool
+                    },
+                    IgniteField {
+                        name: "DEC".to_string(),
+                        r#type: IgniteType::Decimal(-1, -1)
+                    },
+                    IgniteField {
+                        name: "INT".to_string(),
+                        r#type: IgniteType::Int
+                    },
+                    IgniteField {
+                        name: "SMALL".to_string(),
+                        r#type: IgniteType::Short
+                    },
+                    IgniteField {
+                        name: "CHAR".to_string(),
+                        r#type: IgniteType::String
+                    },
+                    IgniteField {
+                        name: "VAR".to_string(),
+                        r#type: IgniteType::String
+                    },
+                    IgniteField {
+                        name: "TS".to_string(),
+                        r#type: IgniteType::Timestamp
+                    }
+                ]
+            }
+        );
+    }
 }

--- a/ignite-rs/tests/resources/rainbow.sql
+++ b/ignite-rs/tests/resources/rainbow.sql
@@ -1,19 +1,19 @@
 -- https://ignite.apache.org/docs/latest/sql-reference/data-types
 create table rainbow (
-     id UUID, -- java.util.UUID
+--      id UUID, -- java.util.UUID -- TODO: add support for this type
      big BIGINT, -- java.lang.Long
      bool BOOLEAN, -- java.lang.Boolean
      dec DECIMAL, -- java.math.BigDecimal
-     double DOUBLE, -- java.lang.Double
+--      double DOUBLE, -- java.lang.Double -- TODO: add support for this type
      int INT, -- java.lang.Integer
-     real REAL, -- java.lang.Float
+--      real REAL, -- java.lang.Float -- TODO: add support for this type
      small SMALLINT, -- java.lang.Short
-     tiny TINYINT, -- java.lang.Byte
+--      tiny TINYINT, -- java.lang.Byte -- TODO: add support for this type
      char CHAR, -- java.lang.String
      var VARCHAR, -- java.lang.String
-     date DATE, -- java.sql.Date
-     time TIME, -- java.sql.Time
+--      date DATE, -- java.sql.Date -- TODO: add support for this type
+--      time TIME, -- java.sql.Time -- TODO: add support for this type
      ts TIMESTAMP, -- java.sql.Timestamp
-     bin BINARY, -- byte[]
-     primary key (id)
+--      bin BINARY, -- byte[] -- TODO: add support for this type
+     primary key (big)
 );


### PR DESCRIPTION
Currently, the `ignite-rs` crate only allows reading and writing hard-coded types (which is good, given most use-cases and Rust's predominately static nature).

However, there are certain use-cases that would benefit from working with runtime types (i.e. Ignite is being used as a SQL database, and users can alter schema at runtime).

This PR is the first in a series that would add runtime type & runtime record support. It adds a `ComplexObjectSchema` type that can later be referenced by a runtime `ComplexObject` and used via the normal cache methods, i.e.:

```
        let cache = ignite
            .get_or_create_cache::<ComplexObject, ComplexObject>(table_name)
            .unwrap();
        cache.put(&key, &val).unwrap();
```

or 

```
        let rows = cache
            .query_scan_sql(100, type_name, "order by block_number desc limit 1")
            .unwrap();
```